### PR TITLE
Expose the ViewWrapper class's current refresh state 

### DIFF
--- a/PullToRefresharp.Android/PullToRefresharp.Views/ViewWrapper.cs
+++ b/PullToRefresharp.Android/PullToRefresharp.Views/ViewWrapper.cs
@@ -60,7 +60,11 @@ namespace PullToRefresharp.Android.Views
 
         public int SnapbackDuration;
         public bool IsPullEnabled;
-        public readonly PullToRefresharpRefreshState State;
+        public PullToRefresharpRefreshState State {
+			get {
+				return refresh_state;
+			}
+		}
 
         public IPullToRefresharpWrappedView ContentView {
             get;


### PR DESCRIPTION
I need to determine the current refresh state to know if a HUD display should be shown.  I don't want it to be displayed if the current busy state is in response to the refresh operation.  Prior to my modification, it always indicated the component was in the "PullToRefresh" state.
